### PR TITLE
fix main cfg dot node issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,19 @@ This will start the application on http://localhost:3000
 
 ---
 
-### ✅ Recent Fixes (2026-05-23)
+### ⚙️ Recent Fixes (2026-05-23)
 
-- Fixed an intermittent CFG rendering bug where only one node was shown after uploading `.c` files.
+- Fixed an intermittent CFG rendering bug where only one node was shown after uploading files.
   - Root cause: multiple function `.dot` files were generated, but a single JSON output (`before.json` / `after.json`) sometimes reflected only one function graph.
   - Fix: CFG generation now prefers `main` using `-cfg-func-name=main` for stable comparisons, and falls back to the first defined function when `main` is not present.
 - Updated Docker LLVM installation targets to `15~20` (bookworm-compatible).
   - `llvm-toolchain-bookworm-14` is no longer available on `apt.llvm.org`, so LLVM 14 was removed from local Docker setup and upload UI options.
 
-> Note: if `main` is absent, LLVM-FLOW now falls back automatically to another defined function instead of failing immediately.
+---
+
+### ✏️ TODO
+
+- Consider replacing the current fixed-function strategy (`main` first, then fallback to first defined function) with a function-selection workflow so users can choose exactly which function CFG to render.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ This will start the application on http://localhost:3000
 
 ---
 
+### ✅ Recent Fixes (2026-05-23)
+
+- Fixed an intermittent CFG rendering bug where only one node was shown after uploading `.c` files.
+  - Root cause: multiple function `.dot` files were generated, but a single JSON output (`before.json` / `after.json`) sometimes reflected only one function graph.
+  - Fix: CFG generation is now pinned to `main` using `-cfg-func-name=main`, so the graph output is stable and deterministic for comparisons.
+- Updated Docker LLVM installation targets to `15~20` (bookworm-compatible).
+  - `llvm-toolchain-bookworm-14` is no longer available on `apt.llvm.org`, so LLVM 14 was removed from local Docker setup and upload UI options.
+
+> Note: if the input module has no `main` function, CFG generation for this flow can fail.
+
+---
+
 ### ✅ Features
 
 1. Detect the same Basic Block between IR modules

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ This will start the application on http://localhost:3000
 - Fixed an intermittent CFG rendering bug where only one node was shown after uploading files.
   - Root cause: multiple function `.dot` files were generated, but a single JSON output (`before.json` / `after.json`) sometimes reflected only one function graph.
   - Fix: CFG generation now prefers `main` using `-cfg-func-name=main` for stable comparisons, and falls back to the first defined function when `main` is not present.
-- Updated Docker LLVM installation targets to `15~20` (bookworm-compatible).
-  - `llvm-toolchain-bookworm-14` is no longer available on `apt.llvm.org`, so LLVM 14 was removed from local Docker setup and upload UI options.
+- Updated Docker LLVM setup for bookworm compatibility.
+  - LLVM `15~20` is installed via `apt.llvm.org`.
+  - LLVM `14` is installed through a separate Debian package path because `llvm-toolchain-bookworm-14` is not available on `apt.llvm.org`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ This will start the application on http://localhost:3000
 
 - Fixed an intermittent CFG rendering bug where only one node was shown after uploading `.c` files.
   - Root cause: multiple function `.dot` files were generated, but a single JSON output (`before.json` / `after.json`) sometimes reflected only one function graph.
-  - Fix: CFG generation is now pinned to `main` using `-cfg-func-name=main`, so the graph output is stable and deterministic for comparisons.
+  - Fix: CFG generation now prefers `main` using `-cfg-func-name=main` for stable comparisons, and falls back to the first defined function when `main` is not present.
 - Updated Docker LLVM installation targets to `15~20` (bookworm-compatible).
   - `llvm-toolchain-bookworm-14` is no longer available on `apt.llvm.org`, so LLVM 14 was removed from local Docker setup and upload UI options.
 
-> Note: if the input module has no `main` function, CFG generation for this flow can fail.
+> Note: if `main` is absent, LLVM-FLOW now falls back automatically to another defined function instead of failing immediately.
 
 ---
 

--- a/llvm-flow-api/Dockerfile
+++ b/llvm-flow-api/Dockerfile
@@ -1,5 +1,8 @@
 # Use an official Python runtime as a parent image
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
+
+# Use HTTPS for Debian mirrors to reduce proxy/cache tampering risk.
+RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -14,19 +17,13 @@ RUN apt-get update && apt-get install -y \
     libzstd-dev \
     ca-certificates \
     gpg \
+    cmake \
     ninja-build \
     && rm -rf /var/lib/apt/lists/*
 
-
-# Install CMake 4.0.2 from release page instead of manually builing it
-RUN test -f /usr/share/doc/kitware-archive-keyring/copyright || \
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-RUN apt-get update && apt-get install -y cmake
-
 COPY llvm.sh /tmp/llvm.sh
 RUN chmod +x /tmp/llvm.sh && \
-    for version in 14 15 16 17 18 19 20; do \
+    for version in 15 16 17 18 19 20; do \
         /tmp/llvm.sh $version; \
     done
 ENV LLVM_ROOT=/usr/lib/llvm-20

--- a/llvm-flow-api/Dockerfile
+++ b/llvm-flow-api/Dockerfile
@@ -26,6 +26,16 @@ RUN chmod +x /tmp/llvm.sh && \
     for version in 15 16 17 18 19 20; do \
         /tmp/llvm.sh $version; \
     done
+
+# Install LLVM/Clang 14 from Debian bookworm repositories as a separate path.
+# (apt.llvm.org does not provide llvm-toolchain-bookworm-14.)
+RUN apt-get update && apt-get install -y \
+    llvm-14 \
+    llvm-14-dev \
+    llvm-14-tools \
+    clang-14 \
+    lld-14 \
+    && rm -rf /var/lib/apt/lists/*
 ENV LLVM_ROOT=/usr/lib/llvm-20
 
 # Download llvm-block source code & build

--- a/llvm-flow-api/Dockerfile
+++ b/llvm-flow-api/Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /llvm-block
 RUN wget https://github.com/kc-ml2/llvm-block/archive/refs/tags/v1.0.2.tar.gz -O llvm-block.tar.gz && \
     tar -xzf llvm-block.tar.gz --strip-components=1 && \
     rm llvm-block.tar.gz
-RUN  cmake --preset=default && cmake --build build 
+RUN cmake -S . -B build && cmake --build build
 RUN cp build/llvm-block/llvm-block /usr/bin/llvm-block
 
 RUN mkdir /var/run/sshd

--- a/llvm-flow-api/app/api/endpoints.py
+++ b/llvm-flow-api/app/api/endpoints.py
@@ -175,6 +175,12 @@ async def upload(
 ) -> OptimizationPostResponse:
     # Validate the format of file_names and opt_passes
     opt_passes: list[str] = validate_string_comma_separated(opt_passes)
+    allowed_llvm_versions = {14, 15, 16, 17, 18, 19, 20}
+    if llvm_version not in allowed_llvm_versions:
+        raise HTTPException(
+            status_code=422,
+            detail="Invalid llvm_version. Allowed versions: 14, 15, 16, 17, 18, 19, 20",
+        )
 
     if TEST_MODE:
         return make_test_result()

--- a/llvm-flow-api/app/api/shell_scripts.py
+++ b/llvm-flow-api/app/api/shell_scripts.py
@@ -26,9 +26,9 @@ llvm-block beforeg.ll afterg.ll 2> output.tsv && \
 $LLVM_BIN_PATH/opt -S beforeg.ll -o before.ll -strip-debug && \
 $LLVM_BIN_PATH/opt -strip-debug -S afterg.ll -o after.ll && \
 mkdir before after && \
-$LLVM_BIN_PATH/opt -passes=dot-cfg before.ll && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main before.ll && \
 mv .*.dot before && \
-$LLVM_BIN_PATH/opt -passes=dot-cfg after.ll && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main after.ll && \
 mv .*.dot after && \
 cd before && \
 dot -Txdot_json -o before.json .*.dot && \
@@ -45,9 +45,9 @@ llvm-block beforeg.ll afterg.ll 2> output.tsv && \
 $LLVM_BIN_PATH/opt -S beforeg.ll -o before.ll -strip-debug && \
 $LLVM_BIN_PATH/opt -strip-debug -S afterg.ll -o after.ll && \
 mkdir before after && \
-$LLVM_BIN_PATH/opt -passes=dot-cfg before.ll && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main before.ll && \
 mv .*.dot before && \
-$LLVM_BIN_PATH/opt -passes=dot-cfg after.ll && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main after.ll && \
 mv .*.dot after && \
 cd before && \
 dot -Txdot_json -o before.json .*.dot && \
@@ -62,9 +62,9 @@ llvm-block beforeg.ll afterg.ll 2> output.tsv && \
 $LLVM_BIN_PATH/opt -S beforeg.ll -o before.ll -strip-debug && \
 $LLVM_BIN_PATH/opt -strip-debug -S afterg.ll -o after.ll && \
 mkdir before after && \
-$LLVM_BIN_PATH/opt -passes=dot-cfg before.ll && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main before.ll && \
 mv .*.dot before && \
-$LLVM_BIN_PATH/opt -passes=dot-cfg after.ll && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main after.ll && \
 mv .*.dot after && \
 cd before && \
 dot -Txdot_json -o before.json .*.dot && \

--- a/llvm-flow-api/app/api/shell_scripts.py
+++ b/llvm-flow-api/app/api/shell_scripts.py
@@ -26,9 +26,15 @@ llvm-block beforeg.ll afterg.ll 2> output.tsv && \
 $LLVM_BIN_PATH/opt -S beforeg.ll -o before.ll -strip-debug && \
 $LLVM_BIN_PATH/opt -strip-debug -S afterg.ll -o after.ll && \
 mkdir before after && \
-$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main before.ll && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main before.ll || true && \
+if ls .*.dot >/dev/null 2>&1; then CFG_FUNC_BEFORE=main; else CFG_FUNC_BEFORE=$(sed -n 's/^define[[:space:]].*@\"\\([^\"]*\\)\".*/\\1/p; t; s/^define[[:space:]].*@\\([^ (]*\\).*/\\1/p' before.ll | head -n 1); fi && \
+if [ -n "$CFG_FUNC_BEFORE" ]; then true; else echo "No defined function found in before.ll" >&2; exit 1; fi && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name="$CFG_FUNC_BEFORE" before.ll && \
 mv .*.dot before && \
-$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main after.ll && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name="$CFG_FUNC_BEFORE" after.ll || true && \
+if ls .*.dot >/dev/null 2>&1; then true; else CFG_FUNC_AFTER=$(sed -n 's/^define[[:space:]].*@\"\\([^\"]*\\)\".*/\\1/p; t; s/^define[[:space:]].*@\\([^ (]*\\).*/\\1/p' after.ll | head -n 1); fi && \
+if [ -n "$CFG_FUNC_AFTER" ]; then $LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name="$CFG_FUNC_AFTER" after.ll; else true; fi && \
+if ls .*.dot >/dev/null 2>&1; then true; else echo "No defined function found in after.ll" >&2; exit 1; fi && \
 mv .*.dot after && \
 cd before && \
 dot -Txdot_json -o before.json .*.dot && \
@@ -45,9 +51,15 @@ llvm-block beforeg.ll afterg.ll 2> output.tsv && \
 $LLVM_BIN_PATH/opt -S beforeg.ll -o before.ll -strip-debug && \
 $LLVM_BIN_PATH/opt -strip-debug -S afterg.ll -o after.ll && \
 mkdir before after && \
-$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main before.ll && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main before.ll || true && \
+if ls .*.dot >/dev/null 2>&1; then CFG_FUNC_BEFORE=main; else CFG_FUNC_BEFORE=$(sed -n 's/^define[[:space:]].*@\"\\([^\"]*\\)\".*/\\1/p; t; s/^define[[:space:]].*@\\([^ (]*\\).*/\\1/p' before.ll | head -n 1); fi && \
+if [ -n "$CFG_FUNC_BEFORE" ]; then true; else echo "No defined function found in before.ll" >&2; exit 1; fi && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name="$CFG_FUNC_BEFORE" before.ll && \
 mv .*.dot before && \
-$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main after.ll && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name="$CFG_FUNC_BEFORE" after.ll || true && \
+if ls .*.dot >/dev/null 2>&1; then true; else CFG_FUNC_AFTER=$(sed -n 's/^define[[:space:]].*@\"\\([^\"]*\\)\".*/\\1/p; t; s/^define[[:space:]].*@\\([^ (]*\\).*/\\1/p' after.ll | head -n 1); fi && \
+if [ -n "$CFG_FUNC_AFTER" ]; then $LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name="$CFG_FUNC_AFTER" after.ll; else true; fi && \
+if ls .*.dot >/dev/null 2>&1; then true; else echo "No defined function found in after.ll" >&2; exit 1; fi && \
 mv .*.dot after && \
 cd before && \
 dot -Txdot_json -o before.json .*.dot && \
@@ -62,9 +74,15 @@ llvm-block beforeg.ll afterg.ll 2> output.tsv && \
 $LLVM_BIN_PATH/opt -S beforeg.ll -o before.ll -strip-debug && \
 $LLVM_BIN_PATH/opt -strip-debug -S afterg.ll -o after.ll && \
 mkdir before after && \
-$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main before.ll && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main before.ll || true && \
+if ls .*.dot >/dev/null 2>&1; then CFG_FUNC_BEFORE=main; else CFG_FUNC_BEFORE=$(sed -n 's/^define[[:space:]].*@\"\\([^\"]*\\)\".*/\\1/p; t; s/^define[[:space:]].*@\\([^ (]*\\).*/\\1/p' before.ll | head -n 1); fi && \
+if [ -n "$CFG_FUNC_BEFORE" ]; then true; else echo "No defined function found in before.ll" >&2; exit 1; fi && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name="$CFG_FUNC_BEFORE" before.ll && \
 mv .*.dot before && \
-$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name=main after.ll && \
+$LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name="$CFG_FUNC_BEFORE" after.ll || true && \
+if ls .*.dot >/dev/null 2>&1; then true; else CFG_FUNC_AFTER=$(sed -n 's/^define[[:space:]].*@\"\\([^\"]*\\)\".*/\\1/p; t; s/^define[[:space:]].*@\\([^ (]*\\).*/\\1/p' after.ll | head -n 1); fi && \
+if [ -n "$CFG_FUNC_AFTER" ]; then $LLVM_BIN_PATH/opt -passes=dot-cfg -cfg-func-name="$CFG_FUNC_AFTER" after.ll; else true; fi && \
+if ls .*.dot >/dev/null 2>&1; then true; else echo "No defined function found in after.ll" >&2; exit 1; fi && \
 mv .*.dot after && \
 cd before && \
 dot -Txdot_json -o before.json .*.dot && \

--- a/llvm-flow-api/llvm.sh
+++ b/llvm-flow-api/llvm.sh
@@ -20,7 +20,7 @@ usage() {
 }
 
 CURRENT_LLVM_STABLE=19
-BASE_URL="http://apt.llvm.org"
+BASE_URL="https://apt.llvm.org"
 
 NEW_DEBIAN_DISTROS=("trixie" "unstable")
 # Set default values for commandline arguments

--- a/llvm-flow-frontend/src/components/pages/upload/upload.tsx
+++ b/llvm-flow-frontend/src/components/pages/upload/upload.tsx
@@ -187,7 +187,6 @@ function Upload() {
         <div className={styles.llvm_version}>
           <label htmlFor="llvm_version">LLVM Version</label>
           <select name="llvm_version" id="llvm_version">
-            <option value="14">14</option>
             <option value="15">15</option>
             <option value="16">16</option>
             <option value="17">17</option>

--- a/llvm-flow-frontend/src/components/pages/upload/upload.tsx
+++ b/llvm-flow-frontend/src/components/pages/upload/upload.tsx
@@ -187,6 +187,7 @@ function Upload() {
         <div className={styles.llvm_version}>
           <label htmlFor="llvm_version">LLVM Version</label>
           <select name="llvm_version" id="llvm_version">
+            <option value="14">14</option>
             <option value="15">15</option>
             <option value="16">16</option>
             <option value="17">17</option>


### PR DESCRIPTION
### Summary
This PR stabilizes CFG generation, improves Docker build reliability on Debian bookworm, and restores LLVM 14 support through a separate installation path.

### Key Changes

#### 1. CFG rendering fix for intermittent single-node output
- Updated CFG extraction to prefer `main` via `-cfg-func-name=main`.
- Added fallback logic when `main` is missing:
  - Automatically selects the first defined function instead of failing immediately.
- Applied consistently across C / CPP / LL upload flows.

#### 2. Docker build compatibility improvements
- Switched API base image to `python:3.12-bookworm`.
- Enforced HTTPS for Debian mirrors in container setup.
- Removed Kitware apt repo dependency for CMake.
- Replaced preset-based build step for `llvm-block` with:
  - `cmake -S . -B build && cmake --build build`
- Updated `apt.llvm.org` base URL in `llvm.sh` to HTTPS.

#### 3. LLVM 14 support restored
- Kept LLVM 15~20 installation through `apt.llvm.org`.
- Added separate LLVM/Clang 14 installation via Debian packages on bookworm:
  - `llvm-14`, `llvm-14-dev`, `llvm-14-tools`, `clang-14`, `lld-14`
- Re-added LLVM 14 option in frontend upload selector.

#### 4. API validation hardening
- `llvm_version` now explicitly validated to allowed set: `14..20`.
- Invalid versions return clear `422` with explicit allowed values.

#### 5. Documentation updates
- Added “Recent Fixes” section describing root cause and resolution.
- Documented fallback behavior when `main` is absent.
- Added TODO note about future enhancement:
  - user-selectable function target for CFG rendering (instead of fixed-function strategy).

---

### Why
- Fixes a user-facing bug where CFG sometimes rendered only one node due to function selection ambiguity in dot/json generation.
- Prevents hard failures for modules without `main`.
- Resolves repeated Docker build failures tied to repository/signing/version compatibility on newer Debian environments.
- Keeps LLVM 14 available for users who need it.

---

### Impact
- More stable and predictable CFG visualization.
- Better resilience for non-`main` IR modules.
- More reliable local Docker builds.
- Preserves compatibility for LLVM 14 workflows.

---

### Notes
- Current fallback may still choose a different function between before/after modules in some optimization edge cases.
- Next planned improvement: allow users to select the function name explicitly in UI/API for deterministic comparison.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed intermittent CFG rendering issue where only a single node appeared after file uploads
  * Improved CFG function selection to prioritize the `main` function with automatic fallback

* **Documentation**
  * Added recent fixes documentation including environment updates for improved compatibility

* **Chores**
  * Updated Docker environment to use Debian bookworm with LLVM toolchain enhancements and added LLVM version validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kc-ml2/llvm-flow/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->